### PR TITLE
Add reset method.  Add it to slot props.

### DIFF
--- a/index.js
+++ b/index.js
@@ -181,6 +181,11 @@ module.exports =
           'content-type': 'application/x-www-form-urlencoded'
         }
       });
+    },
+    // Reset form data back to initial state
+    reset: function () {
+      this.submitting = false;
+      return this.submitted = false;
     }
   }
 });
@@ -405,6 +410,7 @@ var render = function() {
       _vm._t("default", null, {
         readonly: _vm.readonly,
         submitting: _vm.submitting,
+        reset: _vm.reset,
         submitted: _vm.submitted
       })
     ],

--- a/index.vue
+++ b/index.vue
@@ -11,6 +11,7 @@ form.netlify-form(
 	slot(
 		:readonly='readonly'
 		:submitting='submitting'
+		:reset='reset'
 		:submitted='submitted')
 
 </template>
@@ -77,5 +78,10 @@ export default
 			url: @endpoint
 			data: new URLSearchParams(@formData).toString()
 			headers: 'content-type': 'application/x-www-form-urlencoded'
+
+		# Reset form data back to initial state
+		reset: ->
+			@submitting = false
+			@submitted = false
 
 </script>


### PR DESCRIPTION
After `vue-netlify-form` has been submitted once, there's currently no way (that I know of) to set it back to its initial state so the user can fill out the form again.  This PR adds a `reset` function.  You can call it directly on the component instance, or call via the slot prop.  This branch works for me in COR locally.  Haven't tested yet on staging.